### PR TITLE
Update CollectionExtensions.cs

### DIFF
--- a/CollectionExtensions.cs
+++ b/CollectionExtensions.cs
@@ -13,6 +13,7 @@ namespace mongodb_replica_set
             var retryPolicy = Policy
                 .Handle<MongoCommandException>()
                 .Or<MongoConnectionException>()
+                .Or<MongoNotPrimaryException>()
                 .WaitAndRetry(2, retryAttempt => 
                     TimeSpan.FromSeconds(Math.Pow(2, retryAttempt)) 
                 );


### PR DESCRIPTION
This patch handles the exception `MongoDB.Driver.MongoNotPrimaryException: Server returned not master error` when the primary node in the replica set is stopped.

Log:

```
Unhandled Exception: MongoDB.Driver.MongoNotPrimaryException: Server returned not master error.
   at MongoDB.Driver.Core.WireProtocol.CommandWireProtocol`1.ProcessReply(ConnectionId connectionId, ReplyMessage`1 reply)
   at MongoDB.Driver.Core.WireProtocol.CommandWireProtocol`1.Execute(IConnection connection, CancellationToken cancellationToken)
   at MongoDB.Driver.Core.Servers.Server.ServerChannel.ExecuteProtocol[TResult](IWireProtocol`1 protocol, CancellationToken cancellationToken)
   at MongoDB.Driver.Core.Servers.Server.ServerChannel.Command[TResult](DatabaseNamespace databaseNamespace, BsonDocument command, IElementNameValidator commandValidator, Func`1 responseHandling, Boolean slaveOk, IBsonSerializer`1 resultSerializer, MessageEncoderSettings messageEncoderSettings, CancellationToken cancellationToken)
   at MongoDB.Driver.Core.Operations.CommandOperationBase`1.ExecuteProtocol(IChannelHandle channel, ServerDescription serverDescription, ReadPreference readPreference, CancellationToken cancellationToken)
   at MongoDB.Driver.Core.Operations.CommandOperationBase`1.ExecuteProtocol(IChannelSource channelSource, ReadPreference readPreference, CancellationToken cancellationToken)
   at MongoDB.Driver.Core.Operations.ReadCommandOperation`1.Execute(IReadBinding binding, CancellationToken cancellationToken)
   at MongoDB.Driver.Core.Operations.FindCommandOperation`1.Execute(IReadBinding binding, CancellationToken cancellationToken)
   at MongoDB.Driver.Core.Operations.FindOperation`1.Execute(IReadBinding binding, CancellationToken cancellationToken)
   at MongoDB.Driver.OperationExecutor.ExecuteReadOperation[TResult](IReadBinding binding, IReadOperation`1 operation, CancellationToken cancellationToken)
   at MongoDB.Driver.MongoCollectionImpl`1.ExecuteReadOperation[TResult](IReadOperation`1 operation, ReadPreference readPreference, CancellationToken cancellationToken)
   at MongoDB.Driver.MongoCollectionImpl`1.ExecuteReadOperation[TResult](IReadOperation`1 operation, CancellationToken cancellationToken)
   at MongoDB.Driver.MongoCollectionImpl`1.FindSync[TProjection](FilterDefinition`1 filter, FindOptions`2 options, CancellationToken cancellationToken)
   at MongoDB.Driver.FindFluent`2.ToCursor(CancellationToken cancellationToken)
   at MongoDB.Driver.IAsyncCursorSourceExtensions.First[TDocument](IAsyncCursorSource`1 source, CancellationToken cancellationToken)
   at MongoDB.Driver.IFindFluentExtensions.First[TDocument,TProjection](IFindFluent`2 find, CancellationToken cancellationToken)
   at mongodb_replica_set.CollectionExtensions.GetRandomImpl[T](IMongoCollection`1 collection) in /app/CollectionExtensions.cs:line 26
   at mongodb_replica_set.CollectionExtensions.<>c__DisplayClass1_0`1.<GetRandom>b__1() in /app/CollectionExtensions.cs:line 20
   at Polly.Policy.<>c__DisplayClass35_0`1.<Execute>b__0(Context ctx, CancellationToken ct)
   at Polly.Policy.<>c__DisplayClass44_0`1.<Execute>b__0(Context ctx, CancellationToken ct)
   at Polly.RetrySyntax.<>c__DisplayClass12_0.<WaitAndRetry>b__1(Context ctx, CancellationToken ct)
   at Polly.Retry.RetryEngine.Implementation[TResult](Func`3 action, Context context, CancellationToken cancellationToken, IEnumerable`1 shouldRetryExceptionPredicates, IEnumerable`1 shouldRetryResultPredicates, Func`1 policyStateFactory)
   at Polly.RetrySyntax.<>c__DisplayClass12_1.<WaitAndRetry>b__0(Action`2 action, Context context, CancellationToken cancellationToken)
   at Polly.Policy.Execute[TResult](Func`3 action, Context context, CancellationToken cancellationToken)
   at Polly.Policy.Execute[TResult](Func`1 action)
   at mongodb_replica_set.CollectionExtensions.GetRandom[T](IMongoCollection`1 collection) in /app/CollectionExtensions.cs:line 20
   at mongodb_replica_set.Program.Main(String[] args) in /app/Program.cs:line 43
```
